### PR TITLE
Update Mage_Catalog.csv

### DIFF
--- a/app/locale/ja_JP/Mage_Catalog.csv
+++ b/app/locale/ja_JP/Mage_Catalog.csv
@@ -716,7 +716,7 @@
 "The product attribute has been saved.","商品属性を保存しました。"
 "The product has been created.","商品を作成しました。"
 "The product has been deleted.","商品を削除しました。"
-"The product has been duplicated.","商品が重複しています。"
+"The product has been duplicated.","商品を複製しました。"
 "The product has been saved.","商品を保存しました。"
 "The product has required options","この商品には必須オプションがあります。"
 "The review has been deleted","レビューを削除しました。"


### PR DESCRIPTION
"商品が重複しています。" を "商品を複製しました。" と変更。
"The product has been duplicated." は商品の「Duplicate」ボタン押下時に表示。
"商品が重複しています。" でも問題無いが、"商品を複製しました。" とした方が焦らないものと思われます。